### PR TITLE
Improved performance of ps_agent_flexible for large number of percepts

### DIFF
--- a/agents/ps_agent_flexible.py
+++ b/agents/ps_agent_flexible.py
@@ -71,7 +71,7 @@ class FlexiblePSAgent(object):
         else:
             raise TypeError('Observation is of a type not supported as dictionary key. You may be able to add a way of handling this type.')
         
-        if dict_key not in self.percept_dict.keys():
+        if dict_key not in self.percept_dict:
             self.percept_dict[dict_key] = self.num_percepts
             self.num_percepts += 1
             #add column to hmatrix, gmatrix


### PR DESCRIPTION
Especially important when using python2.

Explanation: The dictionary `keys()` method returns a list in python2, while in python3 it returns a dict_keys object. Needlessly building a list slows down the code significantly even for a moderate amount of percepts. (My code took about 10x longer to run on the cluster where only python2 is available.)
There is also a tiny speed-up for python3.